### PR TITLE
fix(cert): use system native root certificates bundle

### DIFF
--- a/src/Lmd/Guzzle/Http/Client.php
+++ b/src/Lmd/Guzzle/Http/Client.php
@@ -135,7 +135,7 @@ class Client extends AbstractHasDispatcher implements ClientInterface
 
         if ($certificateAuthority === true) {
             // use bundled CA bundle, set secure defaults
-            $opts[CURLOPT_CAINFO] = __DIR__ . '/Resources/cacert.pem';
+            // $opts[CURLOPT_CAINFO] = __DIR__ . '/Resources/cacert.pem';
             $opts[CURLOPT_SSL_VERIFYPEER] = true;
             $opts[CURLOPT_SSL_VERIFYHOST] = 2;
         } elseif ($certificateAuthority === false) {


### PR DESCRIPTION
Ne plus utiliser le bundle de certificats racines du repo pour fallback sur celui du système (plus à jour).